### PR TITLE
Adjustment after zif_abapgi_definitions change  (#228)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # abaplint SCI client
 
 This project enables [abaplint](https://abaplint.org) to be run in the context of SAP Code Inspector (SCI), allowing immediate feedback to the ABAP developers in their standard editor, SE24 / SE80 / SE38 / ABAP in Eclipse. And also works seamlessly with other places where the code inspector is triggered like ABAP Test Cockpit (ATC).
-
+ 
 ## Overview
 
 The integration requires two parts: The [abaplint Server](https://github.com/abaplint/abaplint-sci-client) and the abaplint Client (this project). When performing code checks through one of the supported editors or transactions, the abaplint Client will collect the necessary objects and dependencies and send them to the abaplint Server to be processed. The server responds with all of the abaplint findings, which are displayed like any other check results in the SAP tools.

--- a/src/zcl_abaplint_abapgit.clas.abap
+++ b/src/zcl_abaplint_abapgit.clas.abap
@@ -29,7 +29,7 @@ CLASS ZCL_ABAPLINT_ABAPGIT IMPLEMENTATION.
   METHOD fetch_config.
 
     TRY.
-        DATA lt_repos TYPE zif_abapgit_definitions=>ty_repo_ref_tt.
+        DATA lt_repos TYPE zif_abapgit_repo_srv=>ty_repo_list.
         lt_repos = zcl_abapgit_repo_srv=>get_instance( )->list( ).
       CATCH zcx_abapgit_exception.
         RETURN.
@@ -64,7 +64,7 @@ CLASS ZCL_ABAPLINT_ABAPGIT IMPLEMENTATION.
   METHOD list_online.
 
     TRY.
-        DATA lt_repos TYPE zif_abapgit_definitions=>ty_repo_ref_tt.
+        DATA lt_repos TYPE zif_abapgit_repo_srv=>ty_repo_list.
         lt_repos = zcl_abapgit_repo_srv=>get_instance( )->list( ).
       CATCH zcx_abapgit_exception.
         RETURN.


### PR DESCRIPTION
* Add "No config found" setting 

Option to decide how "No configuration found" should be handled. 

Closes #222

* Adjustment after zif_abapgi_definitions change

After https://github.com/abapGit/abapGit/pull/4181

* Update README.md

Co-authored-by: Lars Hvam <larshp@hotmail.com>